### PR TITLE
Change spiffs to spiffsb to enable compile on Windows with VSCode and PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pio/
 .git-commit-hash
+.vscode/

--- a/include/json-rpc.h
+++ b/include/json-rpc.h
@@ -4,7 +4,7 @@
 #include "config.h"
 #include "logger.h"
 #include "main.h"
-#include "spiffs.h"
+#include "spiffsb.h"
 
 #include <ArduinoJson.h>
 #include <string>

--- a/include/logger.h
+++ b/include/logger.h
@@ -2,7 +2,8 @@
 #define BLESKOMAT_LOGGER_H
 
 #include "config.h"
-#include "spiffs.h"
+#include "spiffsb.h"
+
 #include <Arduino.h>
 #include <iostream>
 #include <map>

--- a/include/main.h
+++ b/include/main.h
@@ -8,7 +8,6 @@
 #include "json-rpc.h"
 #include "logger.h"
 #include "screen.h"
-#include "spiffs.h"
 #include "util.h"
 
 #include <lnurl.h>

--- a/include/sdcard.h
+++ b/include/sdcard.h
@@ -4,6 +4,7 @@
 #include "FS.h"
 #include "SD.h"
 #include "SPI.h"
+
 #include <iostream>
 #include <string>
 

--- a/include/spiffsb.h
+++ b/include/spiffsb.h
@@ -3,6 +3,7 @@
 
 #include "FS.h"
 #include "SPIFFS.h"
+
 #include <iostream>
 #include <string>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,7 +52,8 @@ build_flags =
 build_flags =
 	'-D FIRMWARE_NAME="Bleskomat DIY"'
 	'-D FIRMWARE_VERSION="v1.3.0"'
-	!echo "'-D FIRMWARE_COMMIT_HASH=\"$(head -1 .git-commit-hash 2>/dev/null || echo -n)\"'"
+	'-D FIRMWARE_COMMIT_HASH="win"'
+;	!echo "'-D FIRMWARE_COMMIT_HASH=\"$(git rev-parse HEAD)\"'"
 
 [env:bleskomat32]
 board = esp32dev

--- a/src/spiffsb.cpp
+++ b/src/spiffsb.cpp
@@ -1,4 +1,4 @@
-#include "spiffs.h"
+#include "spiffsb.h"
 
 namespace {
 


### PR DESCRIPTION
I came to conclution that Windows doesn't see difference between 
#include "spiffs.h" and 
#include "SPIFFS.h"

Therefore I propose to rename spiffs.h to spiffs**b**.h (b stands to Bleskomat).

As I'm noob I could not figure out how to keep -D FIRMWARE_COMMIT_HASH working. Therefore rude workaround in .ini
[firmware]
build_flags =
	'-D FIRMWARE_NAME="Bleskomat DIY"'
	'-D FIRMWARE_VERSION="v1.3.0"'
	'-D FIRMWARE_COMMIT_HASH="win"'
;	!echo "'-D FIRMWARE_COMMIT_HASH=\"$(git rev-parse HEAD)\"'"

Would there be some way to have _if_ clause  in .ini depending of build platform to run "git" correctly on both linux and Windows with same .ini? 

I was also streamlined #include clauses "\"" and "\<" with same amount CRLF's on each.

Pleased to hear back.

Bear with me - this is my 1st c(pp) code change/creation proposal since 2001.